### PR TITLE
Updated installation notes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Documentation
 -------------
 
-The full Chipper manual is available online at ___.
+Full documentation is available as chipper_manual.pdf_ on GitHub.
 
 
 Install from source
@@ -52,3 +52,4 @@ Chipper landing page. You are ready to go!
 
 
 .. _Anaconda: https://www.anaconda.com/distribution/#download-section
+.. _chipper_manual.pdf: https://github.com/asearfos/chipper/blob/master/chipper_manual.pdf

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,54 @@
-Installation
-============
-
-**Install Chipper**
-
-Download the version of Chipper for your operating system. Unzip the folder. Navigate to and double click the executable named chipper.exe which may have a bird as an icon. You will now see a terminal window open and soon after the Chipper landing page. You are ready to go!
-
 Documentation
 -------------
 
 The full Chipper manual is available online at ___.
+
+
+Install from source
+===================
+
+1. Install Anaconda
+
+   Our recommended approach is to use Anaconda_, which is a
+   distribution of Python containing most of the numeric and scientific
+   software needed to get started. If you are a Mac or Linux user, have
+   used Python before and are comfortable using ``pip`` to install
+   software, you may want to skip this step and use your existing Python
+   installation.
+
+
+2. From within a terminal or command prompt window
+
+   We will install most packages with conda::
+
+      $ conda create -n chipper_env python=3.7
+      $ conda activate chipper_env
+      $ git clone https://github.com/asearfos/chipper
+      $ cd chipper
+      $ pip install -r requirements.txt
+
+2.a Additional steps for Windows users::
+
+    pip install  pypiwin32 kivy.deps.sdl2 kivy.deps.glew kivy.deps.gstreamer kivy.deps.glew_dev kivy.deps.sdl2_dev kivy.deps.gstreamer_dev
+
+3. Install kivy packages ::
+
+    garden install --kivy graph
+    garden install --kivy filebrowser
+    garden install --kivy matplotlib
+    garden install --kivy progressspinner
+
+
+Download chipper
+================
+
+
+**Install Chipper**
+
+Download the version of Chipper for your operating system. Unzip the folder.
+Navigate to and double click the executable named chipper.exe which may have
+a bird as an icon. You will now see a terminal window open and soon after the
+Chipper landing page. You are ready to go!
+
+
+.. _Anaconda: https://www.anaconda.com/distribution/#download-section

--- a/chipper/analysis.py
+++ b/chipper/analysis.py
@@ -10,7 +10,7 @@ from kivy.uix.screenmanager import Screen
 from skimage.measure import label, regionprops
 
 import chipper.utils as utils
-from chipper.logging import setup_logger
+from chipper.log import setup_logger
 
 log = setup_logger(logging.INFO)
 

--- a/chipper/command_line.py
+++ b/chipper/command_line.py
@@ -1,11 +1,9 @@
-import logging
 import os
 import time
-import glob
-from chipper.logging import setup_logger
+from chipper.log import get_logger
 from chipper.analysis import Song, output_bout_data
 
-log = setup_logger(logging.INFO)
+log = get_logger(__file__)
 
 
 def run_analysis(input_directory, user_note_thresh, user_syll_sim_thresh,
@@ -20,7 +18,10 @@ def run_analysis(input_directory, user_note_thresh, user_syll_sim_thresh,
     out_path : str
 
     """
-    files = glob.glob(os.path.join(input_directory, '*.gzip'))
+
+    files = [i for i in os.listdir(os.path.join(input_directory))
+             if i.endswith('.gzip')]
+
     if not len(files):
         log.debug("No gzipped files in {}".format(input_directory))
         raise Exception("No gzipped files in {}".format(input_directory))
@@ -57,3 +58,5 @@ def run_analysis(input_directory, user_note_thresh, user_syll_sim_thresh,
         f.write(errors)
     log.info("{0} of {0} complete".format(n_files))
     output_bout_data(out_path, final_output)
+
+

--- a/chipper/log.py
+++ b/chipper/log.py
@@ -160,12 +160,6 @@ def get_logger(logger_name=BASE_LOGGER_NAME, log_level=None,
     -------
     A logging.Logger object with the requested name
 
-    Examples
-    --------
-
-    >>> from chipper.logging import get_logger
-    >>> logger = get_logger(__name__)
-    >>> logger.debug('Test message')
     """
     if BASE_LOGGER_NAME not in logging.Logger.manager.loggerDict.keys():
         setup_logger(**kwargs)


### PR DESCRIPTION
Renamed logging.py to log.py. Kivy doesn't have absolute import defined,
so it tries to read kivy logging.py instead of the global logging.py.
Simple way to overcome this is to rename our logging.